### PR TITLE
[DE-4757] add support to definitions in mode-client

### DIFF
--- a/mode_client/clients.py
+++ b/mode_client/clients.py
@@ -240,22 +240,6 @@ class ModeDefinitionClient(ModeBaseClient):
 
         return parse_obj_as(List[Definition], definitions)
 
-    def create(self, data: Dict[str, Any]) -> Definition:
-        response = self.request("POST", "/definitions", json={"definition": data})
-
-        return Definition.parse_obj(response)
-
-    def update(self, definition_token: str, data: Dict[str, Any]) -> Definition:
-        data = {k: v for k, v in data.items() if v is not None}
-        response = self.request(
-            "POST", f"/definitions/{definition_token}", json={"definition": data}
-        )
-
-        return Definition.parse_obj(response)
-
-    def delete(self, definition_token: str) -> None:
-        self.request("DELETE", f"definitions/{definition_token}")
-
     def sync(
         self, definition_token: str, commit_message: Optional[str] = None
     ) -> Definition:

--- a/mode_client/clients.py
+++ b/mode_client/clients.py
@@ -14,6 +14,7 @@ from mode_client.models import (
     ReportRun,
     ReportRuns,
     Space,
+    Definition,
 )
 
 
@@ -224,6 +225,42 @@ class ModeSpaceClient(ModeBaseClient):
         self.request("DELETE", f"/spaces/{space}")
 
 
+class ModeDefinitionClient(ModeBaseClient):
+    def get(self, definition_token: str) -> Definition:
+        response = self.request("GET", f"/definitions/{definition_token}")
+
+        return Definition.parse_obj(response)
+
+    def list(self, filter_: Optional[str] = None, tokens: Optional[List[str]] = None) -> List[Definition]:
+        params = {"filter": filter_, "tokens": tokens}
+        response = self.request("GET", "/definitions", params=params)
+        definitions = response["_embedded"]["definitions"]
+
+        return parse_obj_as(List[Definition], definitions)
+
+    def create(self, data: Dict[str, Any]) -> Definition:
+        response = self.request("POST", "/definitions", json={"definition": data})
+
+        return Definition.parse_obj(response)
+
+    def update(
+        self, definition_token: str, data: Dict[str, Any]
+    ) -> Definition:
+        data = {k: v for k, v in data.items() if v is not None}
+        response = self.request("POST", f"/definitions/{definition_token}", json={"definition": data})
+
+        return Definition.parse_obj(response)
+
+    def delete(self, definition_token: str) -> None:
+        self.request("DELETE", f"definitions/{definition_token}")
+
+    def sync(self, definition_token: str, commit_message: Optional[str] = None) -> Definition:
+        json = {"commit_message": commit_message}
+        response = self.request("PATCH", f"/definitions/{definition_token}/sync_to_github", json=json)
+
+        return Definition.parse_obj(response)
+
+
 class ModeClient:
     def __init__(self, workspace: str, token: str, password: str):
         self.workspace = workspace
@@ -253,3 +290,8 @@ class ModeClient:
     @property
     def space(self) -> ModeSpaceClient:
         return ModeSpaceClient(self.workspace, self.token, self.password)
+    
+    @property
+    def definition(self) -> ModeDefinitionClient:
+        return ModeDefinitionClient(self.workspace, self.token, self.password)
+

--- a/mode_client/clients.py
+++ b/mode_client/clients.py
@@ -231,7 +231,9 @@ class ModeDefinitionClient(ModeBaseClient):
 
         return Definition.parse_obj(response)
 
-    def list(self, filter_: Optional[str] = None, tokens: Optional[List[str]] = None) -> List[Definition]:
+    def list(
+        self, filter_: Optional[str] = None, tokens: Optional[List[str]] = None
+    ) -> List[Definition]:
         params = {"filter": filter_, "tokens": tokens}
         response = self.request("GET", "/definitions", params=params)
         definitions = response["_embedded"]["definitions"]
@@ -243,20 +245,24 @@ class ModeDefinitionClient(ModeBaseClient):
 
         return Definition.parse_obj(response)
 
-    def update(
-        self, definition_token: str, data: Dict[str, Any]
-    ) -> Definition:
+    def update(self, definition_token: str, data: Dict[str, Any]) -> Definition:
         data = {k: v for k, v in data.items() if v is not None}
-        response = self.request("POST", f"/definitions/{definition_token}", json={"definition": data})
+        response = self.request(
+            "POST", f"/definitions/{definition_token}", json={"definition": data}
+        )
 
         return Definition.parse_obj(response)
 
     def delete(self, definition_token: str) -> None:
         self.request("DELETE", f"definitions/{definition_token}")
 
-    def sync(self, definition_token: str, commit_message: Optional[str] = None) -> Definition:
+    def sync(
+        self, definition_token: str, commit_message: Optional[str] = None
+    ) -> Definition:
         json = {"commit_message": commit_message}
-        response = self.request("PATCH", f"/definitions/{definition_token}/sync_to_github", json=json)
+        response = self.request(
+            "PATCH", f"/definitions/{definition_token}/sync_to_github", json=json
+        )
 
         return Definition.parse_obj(response)
 
@@ -290,8 +296,7 @@ class ModeClient:
     @property
     def space(self) -> ModeSpaceClient:
         return ModeSpaceClient(self.workspace, self.token, self.password)
-    
+
     @property
     def definition(self) -> ModeDefinitionClient:
         return ModeDefinitionClient(self.workspace, self.token, self.password)
-

--- a/mode_client/models.py
+++ b/mode_client/models.py
@@ -109,6 +109,14 @@ class SpaceLinks(BaseModel):
     viewed: Optional[Link]
 
 
+class DefinitionLinks(BaseModel):
+    self: Link
+    creator: Link
+    last_run: Link
+    last_successful_github_sync: Link
+    web_edit: Link
+
+
 class AccountLinks(BaseModel):
     self: Link
     web: Link
@@ -322,6 +330,21 @@ class Space(BaseModel):
     viewed_: Optional[str] = Field(None, alias="viewed?")
     default_access_level: Optional[str]
     links: SpaceLinks = Field(alias="_links")
+
+
+class Definition(BaseModel):
+    token: str
+    id: int
+    name: str
+    description: str
+    source: str
+    data_source_id: str
+    created_at: str
+    updated_at: str
+    last_successful_sync_at: str
+    last_saved_at: str
+    github_link: Optional[str]
+    links: DefinitionLinks = Field(alias="_links")
 
 
 class Account(BaseModel):


### PR DESCRIPTION
we’re using the [mode-client](https://github.com/svinstech/mode-client/blob/main/mode_client/clients.py) we developed and we didn’t have support to definition object

if we want to also sync definitions, the first step is to add this in the client 

Mode API doc:

https://mode.com/developer/api-reference/analytics/definitions/#listDefinitions