### PR TITLE
[hotfix] make 'executed_by' field optional

### DIFF
--- a/mode_client/models.py
+++ b/mode_client/models.py
@@ -41,7 +41,7 @@ class QueryRunLinks(BaseModel):
     query_web: Link
     report_run: Link
     report_run_web: Link
-    executed_by: Link
+    executed_by: Optional[Link]
 
 
 class ReportLinks(BaseModel):


### PR DESCRIPTION
```
    queries = get_query_runs(
  File "/home/circleci/project/exposures/create_exposures.py", line 53, in get_query_runs
    query_runs = mode.query_run.list(report_id, run_id)
  File "/home/circleci/.cache/pypoetry/virtualenvs/mode-dashboards-3aSsmiER-py3.9/lib/python3.9/site-packages/mode_client/clients.py", line 119, in list
    return parse_obj_as(List[QueryRun], response["_embedded"]["query_runs"])
  File "pydantic/tools.py", line 38, in pydantic.tools.parse_obj_as
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 10 validation errors for ParsingModel[List[mode_client.models.QueryRun]]
__root__ -> 0 -> _links -> executed_by
  field required (type=value_error.missing)
__root__ -> 1 -> _links -> executed_by
  field required (type=value_error.missing)
__root__ -> 2 -> _links -> executed_by
  field required (type=value_error.missing)
__root__ -> 3 -> _links -> executed_by
  field required (type=value_error.missing)
__root__ -> 4 -> _links -> executed_by
  field required (type=value_error.missing)
__root__ -> 5 -> _links -> executed_by
  field required (type=value_error.missing)
__root__ -> 6 -> _links -> executed_by
  field required (type=value_error.missing)
__root__ -> 7 -> _links -> executed_by
  field required (type=value_error.missing)
__root__ -> 8 -> _links -> executed_by
  field required (type=value_error.missing)
__root__ -> 9 -> _links -> executed_by
  field required (type=value_error.missing)

```