### PR TITLE
[DE-4896] disable the timeout for read operation

### DIFF
--- a/mode_client/clients.py
+++ b/mode_client/clients.py
@@ -20,10 +20,11 @@ from mode_client.models import (
 
 class ModeBaseClient:
     def __init__(self, workspace: str, token: str, password: str):
+        timeout = httpx.Timeout(10.0, read=None)
         self.client = httpx.Client(
             base_url=f"https://app.mode.com/api/{workspace}",
             auth=httpx.BasicAuth(token, password),
-            timeout=10.0,
+            timeout=timeout,
         )
 
     def request(


### PR DESCRIPTION
Try to fix

```
transports/default.py", line 77, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ReadTimeout: The read operation timed out
```